### PR TITLE
add github user variable for markdown export

### DIFF
--- a/tpls/layouts.go
+++ b/tpls/layouts.go
@@ -19,7 +19,7 @@ __Contributors__
 {{- end}}
 {{end}}
 Released by {{$e.Author.Name}}, {{$e.Date.Format "Mon 02 Jan 2006"}} -
-[see the diff](https://github.com/mh-cbon/{{$.vars.name}}/compare/{{$tagRange.Begin}}...{{$tagRange.End}}#diff)
+[see the diff](https://github.com/{{$.vars.gh_user}}/{{$.vars.name}}/compare/{{$tagRange.Begin}}...{{$tagRange.End}}#diff)
 ______________
 {{end}}
 


### PR DESCRIPTION
This is a potential breaking change, as mc-cbon's stuff will not continue to work. It's possibly worth adding some logic to fire something different if the var is not set during export time.

Fixes #9